### PR TITLE
add retries option to default backend and listen templates

### DIFF
--- a/templates/etc/haproxy/backend.cfg.j2
+++ b/templates/etc/haproxy/backend.cfg.j2
@@ -16,6 +16,10 @@ backend {{ backend.name }}
   source {{ backend.source }}
 {% endif %}
 
+{% if backend.retries is defined %}
+  retries {{ backend.retries }}
+{% endif %}
+
 {% for option in backend.option | default([])%}
   option {{ option }}
 {% endfor %}

--- a/templates/etc/haproxy/defaults.cfg.j2
+++ b/templates/etc/haproxy/defaults.cfg.j2
@@ -14,6 +14,10 @@
   source {{ haproxy_defaults_source }}
 {% endif %}
 
+{% if haproxy_defaults_retries is defined %}
+  retries {{ haproxy_defaults_retries }}
+{% endif %}
+
 {% if haproxy_defaults_option != false %}
 {% for option in haproxy_defaults_option %}
   option {{ option }}

--- a/templates/etc/haproxy/listen.cfg.j2
+++ b/templates/etc/haproxy/listen.cfg.j2
@@ -36,6 +36,10 @@ listen {{ listen.name }}
   source {{ listen.source }}
 {% endif %}
 
+{% if listen.retries is defined %}
+  retries {{ listen.retries }}
+{% endif %}
+
 {% for option in listen.option | default([]) %}
   option {{ option }}
 {% endfor %}


### PR DESCRIPTION
As I did not find an option to set retries then I add this flag to listen backend and default template files